### PR TITLE
Better Support for SBCl and CCL

### DIFF
--- a/src/clever.lisp
+++ b/src/clever.lisp
@@ -38,7 +38,7 @@
       #+ABCL "lisp"
       #+(and :DEC :Ultrix) "lsp"
       #+:VMS "LSP"
-      #+:ccl "LISP"			;Coral
+      #+:ccl "lisp"			;Coral
       #+allegro "lisp" ;or cl ... hmm.
       "lisp"				;For Unix, Exploder, and anyone else
       ))
@@ -53,7 +53,7 @@
       #+(and :DEC :VMS) "FAS"
       #+Lucid (car lucid::*load-binary-pathname-types*)  ;?
       #+KCL "o"
-      #+:ccl "FASL"			;Coral
+      #+:ccl "lx64fsl"			;Coral
       #+LispWorks "fsl"
       #+allegro "fasl"
       #+(and cmu hpux) "hpf"

--- a/src/clever.lisp
+++ b/src/clever.lisp
@@ -169,4 +169,3 @@
 				 ~%but loading source because it's newer.~%"
 				(namestring obj?))
 			(load-it src?)))))))))
-

--- a/src/clever.lisp
+++ b/src/clever.lisp
@@ -40,6 +40,7 @@
       #+:VMS "LSP"
       #+:ccl "lisp"			;Coral
       #+allegro "lisp" ;or cl ... hmm.
+      #+sbcl "lisp"
       "lisp"				;For Unix, Exploder, and anyone else
       ))
 
@@ -58,6 +59,7 @@
       #+allegro "fasl"
       #+(and cmu hpux) "hpf"
       #+abcl "abcl"
+      #+sbcl "fasl"
       ))   ;(or) => nil otherwise
 
 (defvar *compile-if-necessary-p* nil)

--- a/src/eval.lisp
+++ b/src/eval.lisp
@@ -89,7 +89,7 @@
 	;; Intentionally absent: right parenthesis, semicolon, whitespace
 	'(
 	  ;; Non-constituents
-	  "\"#'(,`"
+	  "\"'(,`"
 	  ;; Constituents (more or less)
 	  ;;
 	  ;; Actually we don't want to hack these, since otherwise the

--- a/src/eval.lisp
+++ b/src/eval.lisp
@@ -25,7 +25,7 @@
 
 (defun scheme-eval (form env)
   (eval (scheme-translator:translate form env)))
-      
+
 
 ; Hack to get define-syntaxes communicated from .bin files to system
 ; in which .bin file is loaded.  Calls to *define-syntax!* necessarily
@@ -197,7 +197,7 @@
 	  (*target-package* (scheme-translator:program-env-package env))
 	  (*scheme-read* *scheme-read*))  ;Allow (setq *scheme-read* ...)
       (funcall fun env))))
-	
+
 
 ; TRANSLATE-FILE
 
@@ -374,7 +374,7 @@
                         (system::listener-top-loop ; Seems to work better than system::%top-level
                          ;; You could specify :PROMPT here (see LW:*PROMPT*) but the default is good.
                          :eval-print-hook
-                         #'(lambda (values) 
+                         #'(lambda (values)
                              (let ((*print-case* :downcase))
                                (loop for (result . more) on values
                                      do (write-result result)
@@ -456,4 +456,3 @@
   (set-in-user-env 'scheme::pp		   #'pp)
   (set-in-user-env 'scheme::error	   #'scheme-error)
   (set-in-user-env 'scheme::benchmark-mode #'benchmark-mode))
-


### PR DESCRIPTION
Good Day,

I'm currently a beginner trying get started with Lisp. I've already invested
hours setting up my ideal Emacs & Common Lisp environment with the copious free
time only a student has. Therefore I began searching for a way to learn SICP
through the Common Lisp environment. It was then Mr. Joswig on HN who pointed me
towards pseudoscheme (https://news.ycombinator.com/item?id=16776704).

I decided to mark this Pull Request as a draft because I'm not entirely clear
why removing '#' from the Non-constituents allows the readtable to be
successfully set, and why this only occurs on SBCL. This is out of the two
implementations I tested, the other being CCL. But seeing resources online as sparse
as it is, I wanted to save future beginners some trouble by making this WIP PR public.

Loading pseudoscheme on SBCL v2.1.9 now does seem to work though. I ran some
scheme examples I found online and pasted the results in the description of commit
fba7323. I've also read online that it is most painless to use the version of
scheme (R5RS?) in the textbook and not modern MIT Scheme or Racket (which can
work with a compatibility module). So pseudoscheme seems to fit the bill
perfectly. In fact I think some historical value would be lost if all the
conditionals for ancient implementations were replaced. I think it's pretty cool
code that is 16 years older than me remains a vehicle to learn the timeless
concepts in SICP.

But now I've spent more time fooling around with the tooling instead of the
material so I'll leave it at that.

Cheers, and thanks for pseudoscheme!